### PR TITLE
Digits quasi quoter

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -2,4 +2,5 @@
 :set -optP-include -optPdist/build/autogen/cabal_macros.h
 :set prompt ">> "
 :set -Wall
-
+:set -XTemplateHaskell
+:set -XQuasiQuotes

--- a/digit.cabal
+++ b/digit.cabal
@@ -31,6 +31,7 @@ library
   build-depends:
                     base < 5 && >= 3
                     , lens >= 3.9.2
+                    , template-haskell
 
   ghc-options:
                     -Wall

--- a/src/Data/Digit/Digit1_8.hs
+++ b/src/Data/Digit/Digit1_8.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude, DeriveDataTypeable #-}
 
 -- | A data type with eight nullary constructors [1-8] and combinators.
 module Data.Digit.Digit1_8
@@ -26,6 +26,8 @@ import Data.Digit.D6
 import Data.Digit.D7
 import Data.Digit.D8
 import Control.Lens
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 
 -- $setup
 -- >>> import Prelude
@@ -42,7 +44,7 @@ data Digit1_8 =
   | D6
   | D7
   | D8
-  deriving (Eq, Ord, Bounded)
+  deriving (Eq, Ord, Enum, Bounded, Data, Typeable)
 
 -- | Catamorphism for @Digit1_8@.
 --

--- a/src/Data/Digit/Digit1_9.hs
+++ b/src/Data/Digit/Digit1_9.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude, DeriveDataTypeable #-}
 
 -- | A data type with nine nullary constructors [1-9] and combinators.
 module Data.Digit.Digit1_9
@@ -25,6 +25,8 @@ import Data.Digit.D7
 import Data.Digit.D8
 import Data.Digit.D9
 import Control.Lens
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 
 -- $setup
 -- >>> import Prelude
@@ -41,7 +43,7 @@ data Digit1_9 =
   | D7
   | D8
   | D9
-  deriving (Eq, Ord, Bounded)
+  deriving (Eq, Ord, Enum, Bounded, Data, Typeable)
 
 -- | Catamorphism for @Digit1_9@.
 --


### PR DESCRIPTION
Doctest fails to parse `TemplateHaskell`.

``` hs
[digitQ|4|] :: Digit
-- 4

named [digitQ|4|]  = "four"
named [digitQ|$x|] = "not four, " ++ show x ++ " instead"

mod10D x = let y = mod x 10 in [digitQ|$y|]
```
